### PR TITLE
Change keydown event to keyup

### DIFF
--- a/src/lib/keyboardShortcutHandlers.ts
+++ b/src/lib/keyboardShortcutHandlers.ts
@@ -6,7 +6,7 @@ import {
 } from './gameEventHandlers';
 
 export const addKeyboardShortcutListener = () => {
-  addEventListener('keydown', (e: KeyboardEvent) => {
+  addEventListener('keyup', (e: KeyboardEvent) => {
     const code = e.code;
     const activeEl = document.activeElement;
     // When the focus is not on any input


### PR DESCRIPTION
Keydown events trigger many times when keys keep pressed.
Use keyup events to trigger operations only once.