### PR TITLE
Easy motion

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "b": "npx webpack",
     "bw": "npx webpack --watch",
     "sass": "npx sass src/sass/main.scss public/static/style.css -s compressed",
-    "build": "npm run b && npm run sass"
+    "build": "npm run b && npm run sass",
+    "s": "firebase serve"
   },
   "author": "midori mici",
   "license": "ISC"

--- a/public/index.html
+++ b/public/index.html
@@ -156,19 +156,19 @@
           <li>
             <div>Mute / unmute</div>
             <div>
-              <kbd>m</kbd>
+              <kbd>M</kbd>
             </div>
           </li>
           <li>
             <div>Show / hide pieces on the opposite board</div>
             <div>
-              <kbd>,</kbd>
+              <kbd>&lt;</kbd>
             </div>
           </li>
           <li>
             <div>Show / hide chat list</div>
             <div>
-              <kbd>c</kbd>
+              <kbd>C</kbd>
             </div>
           </li>
           <li>

--- a/public/index.html
+++ b/public/index.html
@@ -193,6 +193,10 @@
             <div><kbd>1</kbd> ~ <kbd>8</kbd> <kbd>1</kbd> ~ <kbd>8</kbd></div>
           </li>
           <li>
+            <div>Move the selection to the specified piece</div>
+            <div><kbd>space</kbd></div>
+          </li>
+          <li>
             <div>Confirm selection</div>
             <div><kbd>enter</kbd></div>
           </li>

--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -193,6 +193,10 @@
             <div><kbd>1</kbd> ~ <kbd>8</kbd> <kbd>1</kbd> ~ <kbd>8</kbd></div>
           </li>
           <li>
+            <div>指定した駒を選択</div>
+            <div><kbd>space</kbd></div>
+          </li>
+          <li>
             <div>選択を確定</div>
             <div><kbd>enter</kbd></div>
           </li>

--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -156,19 +156,19 @@
           <li>
             <div>ミュート / ミュート解除</div>
             <div>
-              <kbd>m</kbd>
+              <kbd>M</kbd>
             </div>
           </li>
           <li>
             <div>反対側の盤面の駒を表示 / 非表示</div>
             <div>
-              <kbd>,</kbd>
+              <kbd>&lt;</kbd>
             </div>
           </li>
           <li>
             <div>チャットを表示 / 非表示</div>
             <div>
-              <kbd>c</kbd>
+              <kbd>C</kbd>
             </div>
           </li>
           <li>

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ export const colors = {
   ivory: 'rgb(240, 227, 206)',
   buff: 'rgb(179, 147, 105)',
   dark: 'rgb(30, 30, 30)',
-  fuchsia: 'rgb(199, 67, 117)',
+  navy: 'rgb(0, 0, 124)',
   grey: 'rgb(150, 150, 150)',
   safe: 'rgb(121, 202, 68)',
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,3 +13,38 @@ export const scales = {
 };
 
 export const BOARD_MAX_INDEX = 7;
+
+export const EASY_MOTION_AVAILABLE_KEYS = [
+  'f',
+  'j',
+  'd',
+  'k',
+  's',
+  'l',
+  'a',
+  ';',
+  'g',
+  'h',
+  'r',
+  'u',
+  'e',
+  'i',
+  'w',
+  'o',
+  'q',
+  'p',
+  't',
+  'y',
+  'v',
+  'n',
+  'm',
+  'c',
+  ',',
+  'x',
+  '.',
+  'z',
+  '/',
+  'b',
+  '5',
+  '7',
+] as const;

--- a/src/game/draw.ts
+++ b/src/game/draw.ts
@@ -1,4 +1,4 @@
-import { BOARD_MAX_INDEX, colors, scales } from '~/config';
+import { BOARD_MAX_INDEX, colors, EASY_MOTION_AVAILABLE_KEYS, scales } from '~/config';
 import { Vec } from './vec';
 
 const BOARD_SIZE = BOARD_MAX_INDEX + 1;
@@ -271,6 +271,23 @@ export default class Draw {
     for (let rank = 0; rank <= BOARD_MAX_INDEX; rank++) {
       this.transparentSquare(boardId, [file, rank], ALPHA * 3);
       this.text(ctx, `${BOARD_SIZE - rank}`, file, rank);
+    }
+  }
+
+  /**
+   * Draw text labels displayed on pieces for easy motion.
+   * @param boardmap Board data.
+   * @param color The color of the player. Whether it is seen from the first player or the last player.
+   */
+  labelsOverPieces(boardMap: BoardMap) {
+    const ctxs = this.ctxs;
+    let index = 0;
+    for (const pos of boardMap.keys()) {
+      const [boardId, x, y] = pos.split(',').map((e) => +e);
+      this.transparentSquare(boardId as BoardId, [x, y], ALPHA * 3);
+      const ctx = ctxs[boardId];
+      this.text(ctx, EASY_MOTION_AVAILABLE_KEYS[index], x, y);
+      index++;
     }
   }
 

--- a/src/game/draw.ts
+++ b/src/game/draw.ts
@@ -194,7 +194,7 @@ export default class Draw {
         .val();
       ctx.beginPath();
       ctx.arc(...coord, this.squareSize / 4, 0, 2 * Math.PI);
-      ctx.fillStyle = isMyPiece ? colors.safe : colors.fuchsia;
+      ctx.fillStyle = isMyPiece ? colors.safe : colors.navy;
       ctx.fill();
     }
   }
@@ -219,16 +219,27 @@ export default class Draw {
    * 半透明の正方形を描画する
    * @param boardId どちらの盤面か
    * @param pos 描画する座標
+   * @param alpha 不透明度
    */
-  private transparentSquare(boardId: BoardId, pos: Vector) {
+  private transparentSquare(boardId: BoardId, pos: Vector, alpha: number) {
     const ctx = this.ctxs[boardId];
     const squareSize: number = this.squareSize;
-    const coord: Vector = [this.margin, this.margin];
     ctx.save();
     ctx.fillStyle = colors.safe;
-    ctx.globalAlpha = ALPHA;
-    ctx.fillRect(...new Vec(pos).mul(squareSize).add(coord).val(), squareSize, squareSize);
+    ctx.globalAlpha = alpha;
+    ctx.fillRect(...this.posToCoord(pos), squareSize, squareSize);
     ctx.restore();
+  }
+
+  /**
+   * Converts a position on a board to a coordinate value.
+   * @param pos A position of a piece.
+   * @returns A left-top coordinate of the corresponding square.
+   */
+  private posToCoord(pos: Vector): Vector {
+    const squareSize: number = this.squareSize;
+    const coord: Vector = [this.margin, this.margin];
+    return new Vec(pos).mul(squareSize).add(coord).val();
   }
 
   /**
@@ -237,7 +248,7 @@ export default class Draw {
    * @param pos 選択中のマス
    */
   selectedSquare(boardId: BoardId, pos: Vector) {
-    this.transparentSquare(boardId, pos);
+    this.transparentSquare(boardId, pos, ALPHA);
   }
 
   /**
@@ -247,7 +258,7 @@ export default class Draw {
    */
   selectedPromotionCandidate(boardId: BoardId, index: 0 | 1 | 2 | 3) {
     const pos: Vector = [index + 2, 3.5];
-    this.transparentSquare(boardId, pos);
+    this.transparentSquare(boardId, pos, ALPHA);
   }
 
   /**
@@ -258,15 +269,23 @@ export default class Draw {
   selectedFile(boardId: BoardId, file: number) {
     const ctx = this.ctxs[boardId];
     for (let rank = 0; rank <= BOARD_MAX_INDEX; rank++) {
-      this.transparentSquare(boardId, [file, rank]);
-      ctx.save();
-      ctx.fillStyle = colors.fuchsia;
-      ctx.fillText(
-        `${BOARD_SIZE - rank}`,
-        (file + 1) * this.squareSize,
-        (rank + 1) * this.squareSize
-      );
-      ctx.restore();
+      this.transparentSquare(boardId, [file, rank], ALPHA * 3);
+      this.text(ctx, `${BOARD_SIZE - rank}`, file, rank);
     }
+  }
+
+  /**
+   * Draw a text on the canvas.
+   * @param ctx Canvas context object to draw the text.
+   * @param t The text to draw.
+   * @param x The x position of the text.
+   * @param y The y position of the text.
+   */
+  private text(ctx: CanvasRenderingContext2D, t: string, x: number, y: number) {
+    ctx.save();
+    ctx.font = 'bold 48px "Cica"';
+    ctx.fillStyle = colors.navy;
+    ctx.fillText(t, (x + 1) * this.squareSize, (y + 1) * this.squareSize);
+    ctx.restore();
   }
 }

--- a/src/lib/canvasHandlers.ts
+++ b/src/lib/canvasHandlers.ts
@@ -118,9 +118,9 @@ export const handlePlayerGameScreen = async (
 
     // Keyboard event
     document.onkeydown = (e: KeyboardEvent) => {
-      const code = e.code;
+      const key = e.key;
       const res = setGameKeyboardShortcut(
-        code,
+        key,
         originPos,
         destPos,
         boardMap,

--- a/src/lib/gameHandlers.ts
+++ b/src/lib/gameHandlers.ts
@@ -18,6 +18,7 @@ import {
   lastMovedPiecePositionState,
   digitRegisterState,
 } from '~/states';
+import { easyMotionWaitingState } from '~/states/game';
 import { useSetState, useState, useValue } from '~/states/stateManager';
 
 /**
@@ -47,6 +48,7 @@ export const drawBoard = () => {
   const isPromoting = useValue(isPromotingState);
   const promotionCandidateIndex = useValue(promotionCandidateIndexState);
   const digitRegister = useValue(digitRegisterState);
+  const easyMotionWaiting = useValue(easyMotionWaitingState);
   draw.board(boardMap, playerColor, showOppositePieces);
   if (isPromoting) {
     // Display options of a promotion.
@@ -61,6 +63,9 @@ export const drawBoard = () => {
     }
     if (digitRegister !== null) {
       draw.selectedFile(activeBoard, digitRegister - 1);
+    }
+    if (easyMotionWaiting) {
+      draw.labelsOverPieces(boardMap);
     }
   }
 };

--- a/src/lib/gameKeyboardHandlers.ts
+++ b/src/lib/gameKeyboardHandlers.ts
@@ -1,11 +1,13 @@
-import { BOARD_MAX_INDEX } from '~/config';
+import { BOARD_MAX_INDEX, EASY_MOTION_AVAILABLE_KEYS } from '~/config';
 import {
   activeBoardState,
+  boardMapState,
   digitRegisterState,
   focusedPositionState,
   lastMovedPiecePositionState,
   promotionCandidateIndexState,
 } from '~/states';
+import { easyMotionWaitingState } from '~/states/game';
 import { useSetState, useState, useValue } from '~/states/stateManager';
 import { drawBoard } from './gameHandlers';
 
@@ -162,6 +164,34 @@ export const handleDigitKeyInput = (digit: number) => {
     // Set selection to the specified position.
     setFocusedPosition([file, BOARD_MAX_INDEX - rank]);
     setDigitRegister(null);
+  }
+  drawBoard();
+};
+
+export const handleEasyMotion = (key: typeof EASY_MOTION_AVAILABLE_KEYS[number] | ' ') => {
+  const setDigitRegister = useSetState(digitRegisterState);
+  setDigitRegister(null);
+
+  const boardMap = useValue(boardMapState);
+  const setActiveBoard = useSetState(activeBoardState);
+  const setFocusedPosition = useSetState(focusedPositionState);
+  const { value: easyMotionWaiting, setState: setEasyMotionWaiting } =
+    useState(easyMotionWaitingState);
+
+  // When the space key is pressed, waits for next command.
+  if (key === ' ') {
+    setEasyMotionWaiting(!easyMotionWaiting);
+  }
+  // When waiting for next command
+  else if (easyMotionWaiting) {
+    const index = EASY_MOTION_AVAILABLE_KEYS.indexOf(key);
+    const [boardId, x, y] = Array.from(boardMap.keys())
+      [index].split(',')
+      .map((e) => +e);
+    // Set selection to the specified position.
+    setActiveBoard(boardId as BoardId);
+    setFocusedPosition([x, y]);
+    setEasyMotionWaiting(false);
   }
   drawBoard();
 };

--- a/src/lib/keyboardShortcutHandlers.ts
+++ b/src/lib/keyboardShortcutHandlers.ts
@@ -85,7 +85,10 @@ export const setGameKeyboardShortcut = (
         return { originPos: null, destPos };
       });
     } else {
+      // Switch active board.
       registerKeyboardShortcut(code, 'Semicolon', handleSwitchActiveBoard);
+
+      // Navigate selecting position.
       registerKeyboardShortcut(code, 'KeyH', handleMoveLeft);
       registerKeyboardShortcut(code, 'ArrowLeft', handleMoveLeft);
       registerKeyboardShortcut(code, 'KeyL', handleMoveRight);
@@ -98,6 +101,8 @@ export const setGameKeyboardShortcut = (
       registerKeyboardShortcut(code, 'KeyD', handleMoveLeftDown);
       registerKeyboardShortcut(code, 'KeyR', handleMoveRightUp);
       registerKeyboardShortcut(code, 'KeyF', handleMoveRightDown);
+
+      // Go to a specified square directly with file and rank numbers.
       registerKeyboardShortcut(code, 'Digit1', () => handleDigitKeyInput(1));
       registerKeyboardShortcut(code, 'Digit2', () => handleDigitKeyInput(2));
       registerKeyboardShortcut(code, 'Digit3', () => handleDigitKeyInput(3));

--- a/src/lib/keyboardShortcutHandlers.ts
+++ b/src/lib/keyboardShortcutHandlers.ts
@@ -29,9 +29,9 @@ export const addKeyboardShortcutListener = () => {
     const activeEl = document.activeElement;
     // When the focus is not on any input
     if (activeEl.tagName !== 'INPUT') {
-      registerKeyboardShortcut(key, 'm', handleToggleMute);
-      registerKeyboardShortcut(key, ',', handleShowHide);
-      registerKeyboardShortcut(key, 'c', handleToggleChatList);
+      registerKeyboardShortcut(key, 'M', handleToggleMute);
+      registerKeyboardShortcut(key, '<', handleShowHide);
+      registerKeyboardShortcut(key, 'C', handleToggleChatList);
       if (key === '?') {
         handleToggleKeyHelp();
       }

--- a/src/lib/keyboardShortcutHandlers.ts
+++ b/src/lib/keyboardShortcutHandlers.ts
@@ -25,20 +25,20 @@ import {
 /** Adds keyup listener to manipulate mute, opposite pieces visibility, and chat list. */
 export const addKeyboardShortcutListener = () => {
   addEventListener('keyup', (e: KeyboardEvent) => {
-    const code = e.code;
+    const key = e.key;
     const activeEl = document.activeElement;
     // When the focus is not on any input
     if (activeEl.tagName !== 'INPUT') {
-      registerKeyboardShortcut(code, 'KeyM', handleToggleMute);
-      registerKeyboardShortcut(code, 'Comma', handleShowHide);
-      registerKeyboardShortcut(code, 'KeyC', handleToggleChatList);
-      if (code === 'Slash' && e.shiftKey) {
+      registerKeyboardShortcut(key, 'm', handleToggleMute);
+      registerKeyboardShortcut(key, ',', handleShowHide);
+      registerKeyboardShortcut(key, 'c', handleToggleChatList);
+      if (key === '?') {
         handleToggleKeyHelp();
       }
     }
     // When the focus is on the chat input
     else if (activeEl.id === 'chat-input') {
-      registerKeyboardShortcut(code, 'Escape', handleHideChatList);
+      registerKeyboardShortcut(key, 'Escape', handleHideChatList);
     }
   });
 };
@@ -47,7 +47,7 @@ const pieces: PieceName[] = ['N', 'B', 'R', 'Q'];
 
 /**
  * Registers shortcut keys to manipulate board.
- * @param code The key inputted.
+ * @param key The key inputted.
  * @param originPos The position of the piece that is selected.
  * @param destPos The destination position of the piece.
  * @param boardMap The current game board.
@@ -57,7 +57,7 @@ const pieces: PieceName[] = ['N', 'B', 'R', 'Q'];
  * @returns `originPos`, `destPos`, `prom`
  */
 export const setGameKeyboardShortcut = (
-  code: string,
+  key: string,
   originPos: Vector | null,
   destPos: Vector | null,
   boardMap: BoardMap,
@@ -69,49 +69,50 @@ export const setGameKeyboardShortcut = (
   if (document.activeElement.tagName !== 'INPUT') {
     const { value: isPromoting, setState: setIsPromoting } = useState(isPromotingState);
     if (isPromoting) {
-      registerKeyboardShortcut(code, 'KeyH', () => handleSelectPromotionCandidate('left'));
-      registerKeyboardShortcut(code, 'ArrowLeft', () => handleSelectPromotionCandidate('left'));
-      registerKeyboardShortcut(code, 'KeyL', () => handleSelectPromotionCandidate('right'));
-      registerKeyboardShortcut(code, 'ArrowRight', () => handleSelectPromotionCandidate('right'));
-      registerKeyboardShortcut(code, 'Enter', () => {
+      registerKeyboardShortcut(key, 'h', () => handleSelectPromotionCandidate('left'));
+      registerKeyboardShortcut(key, 'ArrowLeft', () => handleSelectPromotionCandidate('left'));
+      registerKeyboardShortcut(key, 'l', () => handleSelectPromotionCandidate('right'));
+      registerKeyboardShortcut(key, 'ArrowRight', () => handleSelectPromotionCandidate('right'));
+      registerKeyboardShortcut(key, 'Enter', () => {
         const promoteTo = useValue(promotionCandidateIndexState);
         promote(originPos, destPos, pieces[promoteTo]);
         setIsPromoting(false);
         return { originPos: null, destPos };
       });
-      registerKeyboardShortcut(code, 'Escape', () => {
+      registerKeyboardShortcut(key, 'Escape', () => {
         setIsPromoting(false);
         drawBoard();
         return { originPos: null, destPos };
       });
     } else {
       // Switch active board.
-      registerKeyboardShortcut(code, 'Semicolon', handleSwitchActiveBoard);
+      registerKeyboardShortcut(key, ';', handleSwitchActiveBoard);
 
       // Navigate selecting position.
-      registerKeyboardShortcut(code, 'KeyH', handleMoveLeft);
-      registerKeyboardShortcut(code, 'ArrowLeft', handleMoveLeft);
-      registerKeyboardShortcut(code, 'KeyL', handleMoveRight);
-      registerKeyboardShortcut(code, 'ArrowRight', handleMoveRight);
-      registerKeyboardShortcut(code, 'KeyK', handleMoveUp);
-      registerKeyboardShortcut(code, 'ArrowUp', handleMoveUp);
-      registerKeyboardShortcut(code, 'KeyJ', handleMoveDown);
-      registerKeyboardShortcut(code, 'ArrowDown', handleMoveDown);
-      registerKeyboardShortcut(code, 'KeyE', handleMoveLeftUp);
-      registerKeyboardShortcut(code, 'KeyD', handleMoveLeftDown);
-      registerKeyboardShortcut(code, 'KeyR', handleMoveRightUp);
-      registerKeyboardShortcut(code, 'KeyF', handleMoveRightDown);
+      registerKeyboardShortcut(key, 'h', handleMoveLeft);
+      registerKeyboardShortcut(key, 'ArrowLeft', handleMoveLeft);
+      registerKeyboardShortcut(key, 'l', handleMoveRight);
+      registerKeyboardShortcut(key, 'ArrowRight', handleMoveRight);
+      registerKeyboardShortcut(key, 'k', handleMoveUp);
+      registerKeyboardShortcut(key, 'ArrowUp', handleMoveUp);
+      registerKeyboardShortcut(key, 'j', handleMoveDown);
+      registerKeyboardShortcut(key, 'ArrowDown', handleMoveDown);
+      registerKeyboardShortcut(key, 'e', handleMoveLeftUp);
+      registerKeyboardShortcut(key, 'd', handleMoveLeftDown);
+      registerKeyboardShortcut(key, 'r', handleMoveRightUp);
+      registerKeyboardShortcut(key, 'f', handleMoveRightDown);
 
       // Go to a specified square directly with file and rank numbers.
-      registerKeyboardShortcut(code, 'Digit1', () => handleDigitKeyInput(1));
-      registerKeyboardShortcut(code, 'Digit2', () => handleDigitKeyInput(2));
-      registerKeyboardShortcut(code, 'Digit3', () => handleDigitKeyInput(3));
-      registerKeyboardShortcut(code, 'Digit4', () => handleDigitKeyInput(4));
-      registerKeyboardShortcut(code, 'Digit5', () => handleDigitKeyInput(5));
-      registerKeyboardShortcut(code, 'Digit6', () => handleDigitKeyInput(6));
-      registerKeyboardShortcut(code, 'Digit7', () => handleDigitKeyInput(7));
-      registerKeyboardShortcut(code, 'Digit8', () => handleDigitKeyInput(8));
-      if (code === 'Enter') {
+      registerKeyboardShortcut(key, '1', () => handleDigitKeyInput(1));
+      registerKeyboardShortcut(key, '2', () => handleDigitKeyInput(2));
+      registerKeyboardShortcut(key, '3', () => handleDigitKeyInput(3));
+      registerKeyboardShortcut(key, '4', () => handleDigitKeyInput(4));
+      registerKeyboardShortcut(key, '5', () => handleDigitKeyInput(5));
+      registerKeyboardShortcut(key, '6', () => handleDigitKeyInput(6));
+      registerKeyboardShortcut(key, '7', () => handleDigitKeyInput(7));
+      registerKeyboardShortcut(key, '8', () => handleDigitKeyInput(8));
+
+      if (key === 'Enter') {
         const setDigitRegister = useSetState(digitRegisterState);
         setDigitRegister(null);
         return handleBoardSelection(
@@ -127,6 +128,6 @@ export const setGameKeyboardShortcut = (
   }
 };
 
-const registerKeyboardShortcut = (code: string, key: string, callback: () => void) => {
-  if (code === key) callback();
+const registerKeyboardShortcut = (key: string, keyName: string, callback: () => void) => {
+  if (key === keyName) callback();
 };

--- a/src/states/game.ts
+++ b/src/states/game.ts
@@ -42,3 +42,6 @@ export const digitRegisterState = s<number>(
   null,
   (state) => state !== null && (!Number.isInteger(state) || state <= 0 || state >= 9)
 );
+
+/** Whether the easy motion mode has started and waiting for next command. */
+export const easyMotionWaitingState = s<boolean>(false);


### PR DESCRIPTION
Use `event.key` instead of `event.code`
- `key` ensures that it is the same as the letter printed on the keyboard. When displaying letters on pieces for easy motion, it is confusing if the letter on the display and the keyboard are incongruent.

Add easy motion keyboard shortcut: #19